### PR TITLE
Fix TJA handling for multiplayer TJAs

### DIFF
--- a/src/Parsers.cs
+++ b/src/Parsers.cs
@@ -181,7 +181,6 @@ namespace tja2fumen
                                             scoreInit = baseCourse.scoreInit,
                                             scoreDiff = baseCourse.scoreDiff,
                                             data = new List<string>(baseCourse.data.ToArray()),
-                                            branches = new Dictionary<string, List<TJAMeasure>>(baseCourse.branches)
 
                             };
                         parsedTja.courses[currentCourse].data.Clear();
@@ -212,10 +211,10 @@ namespace tja2fumen
             {
                 var courseSinglePlayer = parsedTja.courses[courseName];
                 var coursePlayerOne = parsedTja.courses[courseName + "P1"];
-                if (coursePlayerOne.data.Count > 0 && courseSinglePlayer.data.Count > 0)
+                if (coursePlayerOne.data.Count > 0 && courseSinglePlayer.data.Count == 0)
                 {
                     var baseCourse = coursePlayerOne;
-                    parsedTja.courses[currentCourse] =
+                    parsedTja.courses[courseName] =
                         new TJACourse { bpm = baseCourse.bpm,
                                         offset = baseCourse.offset,
                                         course = baseCourse.course,
@@ -224,7 +223,6 @@ namespace tja2fumen
                                         scoreInit = baseCourse.scoreInit,
                                         scoreDiff = baseCourse.scoreDiff,
                                         data = new List<string>(baseCourse.data.ToArray()),
-                                        branches = new Dictionary<string, List<TJAMeasure>>(baseCourse.branches)
 
                         };
                 }


### PR DESCRIPTION
These are fixes to make the code match the orginal tja2fumen library.

1. Copies of the TJACourse shouldn't reference 'branches' since it's never populated at this point. This fixes a crash when constructing the dictionary since the argument provided is null.

2. Fix the comparison logic to match. The match condition is that multiplayer data exists, but single-player data does not exist.

3. The loop that is doing the fixups of the data wasn't using the loop variable.

Tested by applying fixes and loading 2 TJAs that had previously failed parsing.