### PR TITLE
Handle TJAs that are missing SCOREINIT and SCOREDIFF

### DIFF
--- a/src/Classes.cs
+++ b/src/Classes.cs
@@ -29,8 +29,9 @@ namespace tja2fumen
         public string course;
         public Int32 level;
         public List<Int32> balloon = new List<Int32>();
-        public Int32 scoreInit;
-        public Int32 scoreDiff;
+        // Set defaults for SCOREINIT and SCOREDIFF to handle TJAs that leave them out entirely
+        public Int32 scoreInit = 300;
+        public Int32 scoreDiff = 120;
         public List<string> data = new List<string>();
         public Dictionary<string, List<TJAMeasure>> branches;
 


### PR DESCRIPTION
Currently, TJAs that don't have those fields don't increment the score when correct hits happen. This fixes that problem by making these files behave as if empty SCOREINIT: and SCOREDIFF: lines were present.

Tested using a TJA missing SCOREINIT and SCOREDIFF lines and verified that the scores incremented properly.