### PR TITLE
Fix phonetic pronunciation (aka SENOTE) bugs

### DIFF
--- a/src/Converters.cs
+++ b/src/Converters.cs
@@ -604,7 +604,7 @@ namespace tja2fumen
                     cluster[i] = note;
                 }
 
-                bool allDons = cluster.Any(note =>
+                bool allDons = cluster.All(note =>
                                            { return note.noteType.StartsWith("Don"); });
 
                 for (int i = 0; i < cluster.Count; i++)
@@ -618,9 +618,7 @@ namespace tja2fumen
                     cluster[i] = note;
                 }
 
-                bool isFastClusterOf4 = (cluster.Count == 4 && cluster.Chunk(cluster.Count - 1)
-                                                                   .First()
-                                                                   .All(note =>
+                bool isFastClusterOf4 = (cluster.Count == 4 && cluster.All(note =>
                                                                         { return note.diff < eighthNoteDuration; }));
 
                 if (!isFastClusterOf4)


### PR DESCRIPTION
1. When trying to replace the last note in a cluster, it should be considering whether the current cluster is a group of 4 notes that are faster than eighths. It was incorrectly looking at the previous cluster. NOTE: this bug is in tja2fumen as well, I am sending them a PR as well.

2. When determining if all notes in a cluster are dons, call All rather than Any.

Tested this using the TJA for 'Koi wa Milk Tea'. Verified 4 measures were correctly encoded. Tested the Don3 case by hand since that TJA didn't exercise that code.