### PR TITLE
Fix computation of shinuchi scores

### DIFF
--- a/src/Classes.cs
+++ b/src/Classes.cs
@@ -28,6 +28,8 @@ namespace tja2fumen
         public float offset;
         public string course = "";
         public Int32 level;
+        public Int32 scoreMode;
+        public Int32 shinutiScore;
         public List<Int32> balloon = new ();
         // Set defaults for SCOREINIT and SCOREDIFF to handle TJAs that leave them out entirely
         public Int32 scoreInit = 300;

--- a/src/Converters.cs
+++ b/src/Converters.cs
@@ -212,7 +212,7 @@ namespace tja2fumen
             return tjaBranchesProcessed;
         }
 
-        public static FumenCourse ConvertTjaToFumen(TJACourse tja, bool convertSilently = false)
+        public static FumenCourse ConvertTjaToFumen(string course, TJACourse tja, bool convertSilently = false)
         {
             var tjaBranchesProcessed = ProcessComands(tja.branches, tja.bpm);
 
@@ -222,6 +222,7 @@ namespace tja2fumen
             fumen.hasBranches = tja.hasBranches;
             fumen.measures = new List<FumenMeasure>();
             fumen.diff = tja.course;
+            fumen.shinuchiScore = tja.shinutiScore;
             
             for (int i = 0; i < nMeasures; i++)
             {
@@ -244,8 +245,10 @@ namespace tja2fumen
             var courseBallons = new List<int>(tja.balloon);
 
             var totalNotes = new Dictionary<string, int> { { "normal", 0 }, { "professional", 0 }, { "master", 0 } };
+            var totalNoteValues = new Dictionary<string, int> { { "normal", 0 }, { "professional", 0 }, { "master", 0 } };
             var totalBallonsHits = new Dictionary<string, int> { { "normal", 0 }, { "professional", 0 }, { "master", 0 } };
-
+            var totalDrumrolls = 0;
+            var totalBigDrumrolls = 0;
             var totalDrumrollsDuration = new Dictionary<string, float> { { "normal", 0 }, { "professional", 0 }, { "master", 0 } };
             List<string>? branchTypes = null;
             List<(float, float)>? branchConditions = null;
@@ -352,9 +355,16 @@ namespace tja2fumen
                                 // Alr?
                                 currentDrumRoll.duration += notePos - 0.0f;
                             }
-                            totalDrumrollsDuration[currentBranch] += (currentDrumRoll.duration * currentDrumRollMultiplier);
+                           
+                            //Console.WriteLine($"Incrementing duration by {currentDrumRoll.duration} {currentDrumRoll.noteType}");
+                            if (currentDrumRoll.noteType.ToLower() == "drumroll")
+                            {
+                                totalDrumrollsDuration[currentBranch] += (currentDrumRoll.duration * currentDrumRollMultiplier);
+                            }
                             currentDrumRoll.duration = (float)((int)currentDrumRoll.duration);
+                            //Console.WriteLine($"Resetting duration to {currentDrumRoll.duration}");
                             currentDrumRoll = new FumenNote();
+                            //currentDrumRollMultiplier = 0;
                             continue;
                         }
 
@@ -385,10 +395,12 @@ namespace tja2fumen
                         case "Drumroll":
                             currentDrumRoll = note;
                             currentDrumRollMultiplier = 1;
+                            totalDrumrolls++;
                             break;
                         case "DRUMROLL":
                             currentDrumRoll = note;
                             currentDrumRollMultiplier = 2;
+                            totalBigDrumrolls++;
                             break;
                         case "Balloon":
                         case "Kusudama":
@@ -415,6 +427,7 @@ namespace tja2fumen
                             if (note.noteType.ToLower().StartsWith("don") || note.noteType.ToLower().StartsWith("ka"))
                             {
                                 totalNotes[currentBranch] += 1;
+                                totalNoteValues[currentBranch] += 1;
                             }
                             break;
                         }
@@ -427,7 +440,7 @@ namespace tja2fumen
                             break;
                         case "DON":
                         case "KA":
-                            totalNotes[currentBranch] += 1;
+                            totalNoteValues[currentBranch] += 1;
                             ptsToAdd = fumen.header.b484_b487_branch_pts_good_big;
                             break;
                         case "Balloon":
@@ -526,20 +539,36 @@ namespace tja2fumen
             if (totalNotes["professional"] != 0)
             {
                 fumen.header.b460_b463_normal_professional_ratio =
-                    (int)(65536 * (totalNotes["normal"] / totalNotes["professional"]));
+                    (int)((65536 * (totalNotes["normal"]) / totalNotes["professional"]));
             }
 
             if (totalNotes["master"] != 0)
             {
                 fumen.header.b464_b467_normal_master_ratio =
-                    (int)(65536 * (totalNotes["normal"] / totalNotes["master"]));
+                    (int)((65536 * (totalNotes["normal"]) / totalNotes["master"]));
+                //Console.WriteLine($"totalNotes: {totalNotes["normal"]} {totalNotes["professional"]} {totalNotes["master"]}");
+                //Console.WriteLine($"ratios: {fumen.header.b460_b463_normal_professional_ratio} {fumen.header.b464_b467_normal_master_ratio}");
             }
 
             // For balloons, the last hit that pops the balloon awards 5000 points, and previous hits award 300 apiece.
             var balloonScore = ((totalBallonsHits.Values.Max() - tja.balloon.Count) * 300) + (tja.balloon.Count * 5000);
 
             // This scaling factor was empirically determined from a few reference files.
-            var drumRollScore = ((totalDrumrollsDuration.Values.Max()) * .872 );
+            //var drumRollScore = ((totalDrumrollsDuration.Values.Max()) * .872 );
+            var drumRollScore = (totalBigDrumrolls * 200) +  (totalDrumrolls * 100) + (totalDrumrollsDuration.Values.Max());
+            if (course == "Hard")
+            {
+                drumRollScore *= .85f;
+            } else if (course == "Easy")
+            {
+                drumRollScore *= 1.269f;
+            } else if (course == "Normal")
+            {
+                drumRollScore *= 1.487f;
+            } else if (course == "Oni")
+            {
+                drumRollScore *= 1.34f;
+            }
 
             // The linearizedScore is the contribution of hitting notes, which is a function of the total note quantity, which
             // is 1 per small note + 2 per large note.
@@ -547,9 +576,28 @@ namespace tja2fumen
 
             // The total score is the value for each note hit. The rounding machinations ensure that it's the smallest multiple of
             // 10 that results in a score >= 1000000
-            var totalScore = linearizedScore / totalNotes.Values.Max();
-            fumen.shinuchiScore = (int)(Math.Ceiling(totalScore / 10) * 10);
+            var totalScore = linearizedScore / totalNoteValues.Values.Max();
 
+            var guessedScore = (int)(Math.Ceiling(totalScore / 10) * 10);
+
+            if (fumen.shinuchiScore != 0 && course == "Oni")
+            {
+                //Console.WriteLine($"SCORE CHECK Computed: {guessedScore} Actual: {fumen.shinuchiScore}");
+            }
+
+            if (Math.Abs(guessedScore - fumen.shinuchiScore) > 10)
+            {
+                fumen.shinuchiScore = guessedScore;
+            }
+
+            /*
+            Console.WriteLine($"Fractional score: {totalScore / 10}");
+            Console.WriteLine($"shinuchiScore: {fumen.shinuchiScore} {fumen.shinuchiScore * totalNotes.Values.Max()}");
+            Console.WriteLine($"{balloonScore} {drumRollScore} {linearizedScore}");
+            Console.WriteLine($"Drumrolls: {totalDrumrolls} {totalBigDrumrolls} {totalDrumrollsDuration.Values.Max()}");
+            Console.WriteLine($"Balloons: {balloonScore} {totalBallonsHits.Values.Max()} {tja.balloon.Count}");
+            Console.WriteLine($"Notes: {totalNotes.Values.Max()} {totalNoteValues.Values.Max()}");
+            */
             return fumen;
         }
 

--- a/src/Parsers.cs
+++ b/src/Parsers.cs
@@ -118,9 +118,22 @@ namespace tja2fumen
                         parsedTja.courses[currentCourse] = course;
                         break;
 
+                    case "SCOREMODE":
+                        course = parsedTja.courses[currentCourse];
+                        course.scoreMode = int.Parse(value);
+                        break;
                     case "SCOREINIT":
                         course = parsedTja.courses[currentCourse];
-                        course.scoreInit = value != "" ? int.Parse(value.Split(",").Last()) : 300;
+                            if (value.Contains(","))
+                        {
+                                Console.WriteLine($"SCOREINIT split: {value.Split(',')[0]} {value.Split(',')[1]}");
+                                // This is an explicit initializer of scoreInit and shinuti
+                                course.shinutiScore = int.Parse(value.Split(',')[1]);
+                                course.scoreInit = int.Parse(value.Split(',')[0]);
+                        } else
+                        {
+                                course.scoreInit = value != "" ? int.Parse(value) : 300;
+                        }
                         parsedTja.courses[currentCourse] = course;
                         break;
                     case "SCOREDIFF":

--- a/src/Tja2Fumen.cs
+++ b/src/Tja2Fumen.cs
@@ -7,7 +7,7 @@
 
             TJASong asd =
                 Parsers.ParseTja("C:\\Users\\renzo\\Documents\\TakoTako\\customSongs\\TJA\\One Last Kiss\\One Last Kiss.tja");
-            FumenCourse course = Converters.ConvertTjaToFumen(asd.courses["Oni"]);
+            FumenCourse course = Converters.ConvertTjaToFumen("Oni", asd.courses["Oni"]);
             var bytes = Writer.getFumenBytes(course);
             File.WriteAllBytes("C:\\Users\\renzo\\Documents\\TakoTako\\customSongs\\TJA\\One Last Kiss\\OLK_cs.bin", bytes);
         }

--- a/src/Writer.cs
+++ b/src/Writer.cs
@@ -16,6 +16,7 @@ namespace tja2fumen
             {
                 bw.Write(song.header.rawBytes);
 
+                Console.WriteLine($"FIRST OFFSET: {song.measures[0].offsetStart}");
                 foreach (FumenMeasure measure in song.measures)
                 {
 


### PR DESCRIPTION
Adjusted the algorithm to incorporate the scoring contributions of large notes, large drumrolls, and balloon pops.

Tested this with 2 distribution songs that have TJAs. Verified they yield the same score after Mekadon plays through.

I don't have a test case for large drum rolls, I have a trusted tester verifying that for me, but I'm pretty confident the algorithm is correct.